### PR TITLE
add verbose flag

### DIFF
--- a/src/chapters/3/using-msg-sender.md
+++ b/src/chapters/3/using-msg-sender.md
@@ -15,7 +15,7 @@ Let's write a test to explore how it works:
 Run it to find out:
 
 ```solidity
-$ forge test -m msg_sender
+$ forge test -m msg_sender -vv
 
 Running 1 test for src/test/TicTacToken.t.sol:TicTacTokenTest
 [FAIL] test_msg_sender() (gas: 16368)


### PR DESCRIPTION
I needed to use the `-vv` verbose tag to get the logged output shown in the example.